### PR TITLE
added Danish, Italian, Finnish translations for allow buttons

### DIFF
--- a/Sources/CorePermissionsSwiftUI/Resources/da.lproj/Localizable.strings
+++ b/Sources/CorePermissionsSwiftUI/Resources/da.lproj/Localizable.strings
@@ -1,0 +1,4 @@
+/* MARK: Allow Button */
+"button_allow" = "TILLADE";
+"button_allowed" = "TILLADT";
+"button_denied" = "NÆGTET";

--- a/Sources/CorePermissionsSwiftUI/Resources/fi.lproj/Localizable.strings
+++ b/Sources/CorePermissionsSwiftUI/Resources/fi.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+/* MARK: Allow Button */
+"button_allow" = "SALLIA";
+"button_allowed" = "SALLITTUA";
+"button_denied" = "KIELLETTY";
+

--- a/Sources/CorePermissionsSwiftUI/Resources/it.lproj/Localizable.strings
+++ b/Sources/CorePermissionsSwiftUI/Resources/it.lproj/Localizable.strings
@@ -1,0 +1,5 @@
+/* MARK: Allow Button */
+"button_allow" = "CONSENTIRE";
+"button_allowed" = "CONSENTITO";
+"button_denied" = "NEGATO";
+


### PR DESCRIPTION
@jevonmao 
Thanks to your implementation in #108 the "ALLOW" buttons could be translated.

Here is the translation for the ALLOW Button and its states in Finnish, Danish, and Italian