### PR TITLE
Supported attributed content in headers

### DIFF
--- a/Sources/CorePermissionsSwiftUI/SwiftUI/Modal-style/ModalView.swift
+++ b/Sources/CorePermissionsSwiftUI/SwiftUI/Modal-style/ModalView.swift
@@ -26,7 +26,7 @@ struct ModalView: View {
                     .padding()
                     .frame(maxWidth:UIScreen.main.bounds.width-30)
 
-                Text(mainText.bottomDescription)
+                Text(.init(mainText.bottomDescription))
                     .font(.system(.callout, design: .rounded))
                     .foregroundColor(Color(.systemGray))
                     .padding(.horizontal)

--- a/Sources/CorePermissionsSwiftUI/SwiftUI/Shared/HeaderView.swift
+++ b/Sources/CorePermissionsSwiftUI/SwiftUI/Shared/HeaderView.swift
@@ -31,14 +31,14 @@ struct HeaderView: View {
                     }
                 
                 HStack {
-                        Text(mainText.headerText)
-                            .font(.system(style == .alert ? .title : .largeTitle, design: .rounded))
-                            .fontWeight(.bold)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.85)
-                            .allowsTightening(true)
-                            .layoutPriority(1)
-                            .accessibility(identifier: "Main title")
+                    Text(.init(mainText.headerText))
+                        .font(.system(style == .alert ? .title : .largeTitle, design: .rounded))
+                        .fontWeight(.bold)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+                        .allowsTightening(true)
+                        .layoutPriority(1)
+                        .accessibility(identifier: "Main title")
                             
                             
                     Spacer()
@@ -56,7 +56,7 @@ struct HeaderView: View {
             .padding(.horizontal, style == .alert ? 0 : 16)
             
             if style == .modal {
-                Text(mainText.headerDescription)
+                Text(.init(mainText.headerDescription))
                     .font(.system(.body, design: .rounded))
                     .fontWeight(.medium)
                     .foregroundColor(Color(.systemGray))


### PR DESCRIPTION
Fixes the styling of attributed markdown strings passed to header set modifiers. Closes #131.


<img width="468" alt="Screenshot 2023-05-12 at 13 45 52" src="https://github.com/jevonmao/PermissionsSwiftUI/assets/82472766/2013e4af-7b4f-4817-ac55-a7323551dd03">
