### PR TITLE
[Chore]: Add biometrical permissions (FaceID, TouchID, OpticID)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,9 +105,16 @@ let permissionsTargets: [Target] = [
         dependencies: ["Introspect", .target(name: "CorePermissionsSwiftUI")],
         exclude: ["../../Tests/PermissionsSwiftUITests/__Snapshots__"]
     ),
-    .target(name: "PermissionsSwiftUISiri",
-            dependencies: ["Introspect", "CorePermissionsSwiftUI"],
-            exclude: ["../../Tests/PermissionsSwiftUITests/__Snapshots__"])]
+    .target(
+        name: "PermissionsSwiftUISiri",
+        dependencies: ["Introspect", "CorePermissionsSwiftUI"],
+        exclude: ["../../Tests/PermissionsSwiftUITests/__Snapshots__"]
+    ),
+    .target(
+        name: "PermissionsSwiftUIBiometrics",
+        dependencies: ["Introspect", .target(name: "CorePermissionsSwiftUI")],
+        exclude: ["../../Tsts/PermissionsSwiftUITests/__Snapshots__"]
+    )]
 
 let package = Package(
     name: "PermissionsSwiftUI",

--- a/Sources/CorePermissionsSwiftUI/Model/PermissionType/PermissionType.swift
+++ b/Sources/CorePermissionsSwiftUI/Model/PermissionType/PermissionType.swift
@@ -40,6 +40,12 @@ public enum PermissionType: Hashable, Equatable {
     ///Permission that allows Siri and Maps to communicate with your app
     case siri
     
+    /// Permission that grants access to biometric authentication in your application.
+    ///
+    /// The `biometrics` permission enables the use of biometric authentication features, such as Face ID, Touch ID or OpticID,
+    /// allowing users to securely authenticate themselves using their unique biometric data.
+    @available(iOS 13, macOS 11, *) case biometrics
+    
     ///In order for app to track user's data across apps and websites, the tracking permission is needed
     @available(iOS 14, tvOS 14, *) case tracking
 #if !os(tvOS)

--- a/Sources/CorePermissionsSwiftUI/Store/ComponentsStore/PermissionComponentsStore.swift
+++ b/Sources/CorePermissionsSwiftUI/Store/ComponentsStore/PermissionComponentsStore.swift
@@ -29,6 +29,13 @@ public struct PermissionComponentsStore {
      */
     public init(){}
     //MARK: Permission Components
+    /// The displayed text and image icon for the biometrics permission
+    public var biometricPermission = JMPermission(
+        imageIcon: AnyView(Image(systemName: "faceid")), 
+        title: "Biometrics",
+        description: "Allow to lock/hide your data from other persons"
+    )
+    
     ///The displayed text and image icon for the camera permission
     public var cameraPermission = JMPermission(
         imageIcon: AnyView(Image(systemName: "camera.fill")),
@@ -132,6 +139,9 @@ extension PermissionComponentsStore {
         case .location:
             modify(&self.locationPermission)
             return self.locationPermission
+        case .biometrics:
+            modify(&self.biometricPermission)
+            return self.biometricPermission
         case .locationAlways:
             modify(&self.locationAlwaysPermission)
             return self.locationAlwaysPermission

--- a/Sources/PermissionsSwiftUIBiometrics/JMBiometricsPermissionManager.swift
+++ b/Sources/PermissionsSwiftUIBiometrics/JMBiometricsPermissionManager.swift
@@ -1,0 +1,77 @@
+//
+//  JMBiometricsPermissionManager.swift
+//
+//
+//  Created by Nevio Hirani on 20.01.24.
+//  Github: N3v1  -
+//
+
+import UIKit
+
+import LocalAuthentication
+import CorePermissionsSwiftUI
+
+/// A permission manager for handling biometric authentication requests.
+@available(iOS 13.0, macOS 11.0, *)
+public extension PermissionManager {
+    /// Shared instance for managing biometric permissions.
+    static let opticBiometrics = JMBiometricPermissionManager()
+}
+
+/// A permission manager specifically designed for handling biometric authentication requests, such as Face ID, Touch ID and Optic ID.
+///
+/// `JMBiometricPermissionManager` provides a streamlined interface for checking and requesting biometric authentication permissions.
+/// It encapsulates the complexities associated with the LocalAuthentication framework, making it easy to integrate biometric security
+/// features into your app. The class is part of the `CorePermissionsSwiftUI` framework and aligns with the standardized `PermissionManager` protocol.
+///
+/// ## Usage
+/// To utilize biometric authentication in your application, follow the guide in the README.md
+@available(iOS 13.0, macOS 11.0, *)
+public final class JMBiometricPermissionManager: PermissionManager {
+    
+    public override var permissionType: PermissionType {
+        .biometrics
+    }
+    
+    /// Retrieves the current authorization status for biometric authentication.
+    ///
+    /// - Returns: The current authorization status, indicating whether biometric authentication is authorized, denied, or not determined.
+    public override var authorizationStatus: AuthorizationStatus {
+        let context = LAContext()
+        var error: NSError?
+        
+        if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
+            return .authorized
+        } else {
+            switch error?.code {
+            case LAError.Code.biometryLockout.rawValue, LAError.Code.biometryNotAvailable.rawValue,
+                LAError.Code.biometryNotEnrolled.rawValue:
+                return .denied
+            default:
+                return .notDetermined
+            }
+        }
+    }
+    
+    /// Requests permission for biometric authentication with a completion handler.
+    ///
+    /// - Parameters:
+    ///   - completion: A closure to be called once the request is processed.
+    ///                 The closure takes a boolean indicating whether the permission was granted
+    ///                 and an optional error in case of failure.
+    public override func requestPermission(completion: @escaping (Bool, Error?) -> Void) {
+        let context = LAContext()
+        
+        let localizedReason = "Authenticate to access biometric features"
+        
+        context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: localizedReason) { success, error in
+            DispatchQueue.main.async {
+                if success {
+                    completion(true, nil)  // Authorized (true), no error
+                } else {
+                    completion(false, error)  // Not authorized (false), with error
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi @jevonmao,
this PR resolves issue #80. I've added biometrical authentication methods like FaceID (iOS 11+), TouchID (iOS 11+) and opticID (visionOS 1.0). I orientated myself on apple's documentation about [Local Authentication](https://developer.apple.com/documentation/localauthentication).

My code doesn't generate any new warnings or errors and is ready to merge after your final review.

Best regards
NH