### PR TITLE
Make EventKit Imports Explicit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,10 @@ let permissionsTargets: [Target] = [
     .target(
         name: "PermissionsSwiftUICalendar",
         dependencies: ["Introspect", "CorePermissionsSwiftUI"],
-        exclude: ["../../Tests/PermissionsSwiftUITests/__Snapshots__"]
+        exclude: ["../../Tests/PermissionsSwiftUITests/__Snapshots__"],
+        swiftSettings: [
+            .define("PERMISSIONSWIFTUI_EVENT")
+        ]
     ),
     .target(
         name: "PermissionsSwiftUICamera",
@@ -93,7 +96,10 @@ let permissionsTargets: [Target] = [
     .target(
         name: "PermissionsSwiftUIReminder",
         dependencies: ["Introspect", "CorePermissionsSwiftUI"],
-        exclude: ["../../Tests/PermissionsSwiftUITests/__Snapshots__"]
+        exclude: ["../../Tests/PermissionsSwiftUITests/__Snapshots__"],
+        swiftSettings: [
+            .define("PERMISSIONSWIFTUI_EVENT")
+        ]
     ),
     .target(
         name: "PermissionsSwiftUISpeech",

--- a/Sources/CorePermissionsSwiftUI/Model/PermissionManagers/EventPermissionManager.swift
+++ b/Sources/CorePermissionsSwiftUI/Model/PermissionManagers/EventPermissionManager.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+
+#if !os(tvOS) && PERMISSIONSWIFTUI_EVENT
 import EventKit
 
 open class EventPermissionManager: PermissionManager {
@@ -52,3 +54,4 @@ open class EventPermissionManager: PermissionManager {
     }
 
 }
+#endif

--- a/Sources/PermissionsSwiftUICalendar/JMCalendarPermissionManager.swift
+++ b/Sources/PermissionsSwiftUICalendar/JMCalendarPermissionManager.swift
@@ -5,8 +5,8 @@
 //  Created by Jevon Mao on 1/31/21.
 //
 
-import UIKit
-#if !os(tvOS)
+import Foundation
+#if !os(tvOS) && PERMISSIONSWIFTUI_EVENT
 import EventKit
 import CorePermissionsSwiftUI
 

--- a/Sources/PermissionsSwiftUIReminder/JMRemindersPermissionManager.swift
+++ b/Sources/PermissionsSwiftUIReminder/JMRemindersPermissionManager.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-#if !os(tvOS)
+#if !os(tvOS) && PERMISSIONSWIFTUI_EVENT
 import EventKit
 import CorePermissionsSwiftUI
 


### PR DESCRIPTION
Release 1.5.8 (#138) exposes `EventKit` in all targets through their dependency on the `CorePermissionsSwiftUI` module. This causes *all* target libraries to reference `EventKit`, even if they don't use it.

This PR:
- Adds a `SwiftSetting` defining a `PERMISSIONSWIFTUI_EVENT` flag to the target definitions for `JMCalendarPermissionManager` and `JMRemindersPermissionManager`
- Wraps `EventPermissionManager`, `JMRemindersPermissionManager`, and `JMCalendarPermissionManager` with a compile time check for `PERMISSIONSWIFTUI_EVENT`
- Fixes #140